### PR TITLE
feat: directly emit wasm hook error

### DIFF
--- a/app/ibc-middleware/util.go
+++ b/app/ibc-middleware/util.go
@@ -87,19 +87,10 @@ func jsonStringHasKey(memo, key string) (found bool, jsonObject map[string]inter
 
 // newEmitErrorAcknowledgement creates a new error acknowledgement after having emitted an event with the
 // details of the error.
-func newEmitErrorAcknowledgement(ctx sdk.Context, err error, errorContexts ...string) channeltypes.Acknowledgement {
-	attributes := make([]sdk.Attribute, len(errorContexts)+1)
-	attributes[0] = sdk.NewAttribute("error", err.Error())
-	for i, s := range errorContexts {
-		attributes[i+1] = sdk.NewAttribute("error-context", s)
+func newEmitErrorAcknowledgement(ctx sdk.Context, err error) channeltypes.Acknowledgement {
+	return channeltypes.Acknowledgement{
+		Response: &channeltypes.Acknowledgement_Error{
+			Error: fmt.Sprintf("ibc wasm hook error: %s", err.Error()),
+		},
 	}
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			"ibc-acknowledgement-error",
-			attributes...,
-		),
-	})
-
-	return channeltypes.NewErrorAcknowledgement(err)
 }


### PR DESCRIPTION
ibc-go use cache context when calling `OnRecvPacket` so the emitted events are ignored. so we create error ack directly not using ibc-go one.