### PR TITLE
bump kvindexer to decrease mem usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/hashicorp/go-metrics v0.5.3
 	github.com/initia-labs/OPinit v0.3.2
 	github.com/initia-labs/initia v0.3.3
-	github.com/initia-labs/kvindexer v0.1.3
+	github.com/initia-labs/kvindexer v0.1.4
 	github.com/initia-labs/kvindexer/submodules/block v0.1.0
 	github.com/initia-labs/kvindexer/submodules/tx v0.1.0
 	github.com/initia-labs/kvindexer/submodules/wasm-nft v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -808,6 +808,8 @@ github.com/initia-labs/initia v0.3.3 h1:82ZkXki6CG+F+rPDBVpTzzSQY8NalXIZ0LnYSWNd
 github.com/initia-labs/initia v0.3.3/go.mod h1:1yWifo9GnhIvwDtCTTN6kb2mfq2On+oel6ha/rBXaQQ=
 github.com/initia-labs/kvindexer v0.1.3 h1:TLkgJjp5TiPnH+OzYfk7ZKQTKqGOfSte59Y3gasob+o=
 github.com/initia-labs/kvindexer v0.1.3/go.mod h1:rvAmgCAmEs4KM8sRRPcyTqNNwi8s2JiHybiFkYfp4KE=
+github.com/initia-labs/kvindexer v0.1.4 h1:dtdDuIFjLCXVTnHCPw8LIl6ry1cnwNhQyRtQdHpCGGU=
+github.com/initia-labs/kvindexer v0.1.4/go.mod h1:rvAmgCAmEs4KM8sRRPcyTqNNwi8s2JiHybiFkYfp4KE=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0 h1:y+EXnksd/I2F96mzIoQA64nZUZON2P+99YrSzeLCLoY=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0/go.mod h1:4c+c59wVAnjuaJv/pcDYaUkeVmOqVV+orqEjya/RIjo=
 github.com/initia-labs/kvindexer/submodules/tx v0.1.0 h1:6kbf6wmzXPN0XCQLasiFgq1AlZHkt5K3/ZG+IWw1nNs=

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,6 @@ github.com/initia-labs/ibc-go/v8 v8.0.0-20240419124350-4275a05abe2c h1:FDwh5zZbm
 github.com/initia-labs/ibc-go/v8 v8.0.0-20240419124350-4275a05abe2c/go.mod h1:wj3qx75iC/XNnsMqbPDCIGs0G6Y3E/lo3bdqCyoCy+8=
 github.com/initia-labs/initia v0.3.3 h1:82ZkXki6CG+F+rPDBVpTzzSQY8NalXIZ0LnYSWNd+3U=
 github.com/initia-labs/initia v0.3.3/go.mod h1:1yWifo9GnhIvwDtCTTN6kb2mfq2On+oel6ha/rBXaQQ=
-github.com/initia-labs/kvindexer v0.1.3 h1:TLkgJjp5TiPnH+OzYfk7ZKQTKqGOfSte59Y3gasob+o=
-github.com/initia-labs/kvindexer v0.1.3/go.mod h1:rvAmgCAmEs4KM8sRRPcyTqNNwi8s2JiHybiFkYfp4KE=
 github.com/initia-labs/kvindexer v0.1.4 h1:dtdDuIFjLCXVTnHCPw8LIl6ry1cnwNhQyRtQdHpCGGU=
 github.com/initia-labs/kvindexer v0.1.4/go.mod h1:rvAmgCAmEs4KM8sRRPcyTqNNwi8s2JiHybiFkYfp4KE=
 github.com/initia-labs/kvindexer/submodules/block v0.1.0 h1:y+EXnksd/I2F96mzIoQA64nZUZON2P+99YrSzeLCLoY=


### PR DESCRIPTION
same as [the one from minimove](https://github.com/initia-labs/minimove/pull/47)
---
kvindexer cache from kvindexer@v0.1.3 consumes too huge memory by default(1M records).
-> sometimes minitiad crashes because of OOM
let's bump kvindexer@v0.1.4 to decrease default to 100k records.