### PR TITLE
Implement CI/CD workflows for miniwasm binary builds

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,0 +1,19 @@
+name: Build and Upload to releases
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-linux-amd64:
+    uses: ./.github/workflows/build-linux-amd64.yml
+
+  build-linux-arm64:
+    uses: ./.github/workflows/build-linux-arm64.yml
+
+  build-darwin-amd64:
+    uses: ./.github/workflows/build-darwin-amd64.yml
+
+  build-darwin-arm64:
+    uses: ./.github/workflows/build-darwin-arm64.yml

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -63,8 +63,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad    

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           go mod tidy
-          go get github.com/initia-labs/movevm@${WASMVM_VERSION}
+          go get github.com/CosmWasm/wasmvm@${WASMVM_VERSION}
 
       - name: Print environment variables
         run: |

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -30,13 +30,13 @@ jobs:
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
-          MOVEVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
-          echo "MOVEVM_VERSION=${MOVEVM_VERSION}" >> $GITHUB_ENV        
+          WASMVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV        
 
       - name: Ensure dependencies
         run: |
           go mod tidy
-          go get github.com/initia-labs/movevm@${MOVEVM_VERSION}
+          go get github.com/initia-labs/movevm@${WASMVM_VERSION}
 
       - name: Print environment variables
         run: |
@@ -44,22 +44,34 @@ jobs:
           echo "GOOS=${GOOS}"
           echo "VERSION=${VERSION}"
           echo "ARCH_NAME=${ARCH_NAME}"
-          echo "MOVEVM_VERSION=${MOVEVM_VERSION}"
+          echo "WASMVM_VERSION=${WASMVM_VERSION}"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
 
-      - name: Build and Package for Darwin ADM64
+      # - name: Build and Package for Darwin ADM64
+      #   run: |
+      #     cd ../miniwasm \
+      #     && make build \
+      #     && cd ./build \
+      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libmovevm.dylib ./ \
+      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libcompiler.dylib ./ \
+      #     && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+      #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+      #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+
+      - name: Build and Package for Darwin ADM642
         run: |
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
-          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
-          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
-          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
-          && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+          && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libwasmvm.dylib ./minitiad    
   
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             miniwasm_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz
+
+            

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -63,6 +63,7 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
+          && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
           && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -63,8 +63,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad    

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -63,8 +63,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad    

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -63,8 +63,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad    

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -1,0 +1,65 @@
+name: Build Darwin AMD64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+
+      - name: Set environment variables
+        run: |
+          MINIWASM_NETWORK_NAME="miniwasm-1"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV        
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+          echo "GOOS=darwin" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
+          MOVEVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          echo "MOVEVM_VERSION=${MOVEVM_VERSION}" >> $GITHUB_ENV        
+
+      - name: Ensure dependencies
+        run: |
+          go mod tidy
+          go get github.com/initia-labs/movevm@${MOVEVM_VERSION}
+
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+          echo "ARCH_NAME=${ARCH_NAME}"
+          echo "MOVEVM_VERSION=${MOVEVM_VERSION}"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
+
+      - name: Build and Package for Darwin ADM64
+        run: |
+          cd ../miniwasm \
+          && make build \
+          && cd ./build \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
+          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+  
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            miniwasm_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -30,8 +30,8 @@ jobs:
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
-          WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | awk '{print $2}')    
-          echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV        
+          WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | awk '{print $2}')
+          echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV 
 
       - name: Ensure dependencies
         run: |

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -30,7 +30,7 @@ jobs:
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
-          WASMVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | awk '{print $2}')    
           echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV        
 
       - name: Ensure dependencies

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -57,8 +57,8 @@ jobs:
           && ls ~/go/pkg/mod/github.com/ \
           && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/ \
           && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
-          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
-          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   
 
       - name: Release

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -54,22 +54,13 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm* \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
-          && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
-          && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
-          && rm -rf ./libwasmvm.dylib ./minitiad    
+          && ls ~/go/pkg/mod/github.com/ \
+          && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/ \
+          && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
+          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libwasmvm.dylib ./minitiad   
 
-        # - name: Build and Package for Darwin ADM64
-        #   run: |
-        #     cd ../miniwasm \
-        #     && make build \
-        #     && cd ./build \
-        #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libmovevm.dylib ./ \
-        #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libcompiler.dylib ./ \
-        #     && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
-        #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
-        #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           go mod tidy
-          go get github.com/CosmWasm/wasmvm@${WASMVM_VERSION}
+          go get github.com/CosmWasm/wasmvm/v2@${WASMVM_VERSION}
 
       - name: Print environment variables
         run: |

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -47,28 +47,29 @@ jobs:
           echo "WASMVM_VERSION=${WASMVM_VERSION}"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
 
-      # - name: Build and Package for Darwin ADM64
-      #   run: |
-      #     cd ../miniwasm \
-      #     && make build \
-      #     && cd ./build \
-      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libmovevm.dylib ./ \
-      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libcompiler.dylib ./ \
-      #     && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
-      #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
-      #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+
 
       - name: Build and Package for Darwin ADM642
         run: |
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm* \
           && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad    
-  
+
+        # - name: Build and Package for Darwin ADM64
+        #   run: |
+        #     cd ../miniwasm \
+        #     && make build \
+        #     && cd ./build \
+        #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libmovevm.dylib ./ \
+        #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libcompiler.dylib ./ \
+        #     && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+        #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+        #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -66,5 +66,3 @@ jobs:
         with:
           files: |
             miniwasm_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz
-
-            

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -61,8 +61,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -56,16 +56,29 @@ jobs:
       #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
       #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
 
-      - name: Build and Package for Darwin ADM642
+      - name: Build and Package for Darwin ADM64
         run: |
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm* \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
-          && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
-          && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
-          && rm -rf ./libwasmvm.dylib ./minitiad   
+          && echo "Contents of /Users/runner/go/pkg/mod/github.com/CosmWasm:" \
+          && ls -l /Users/runner/go/pkg/mod/github.com/CosmWasm \
+          && echo "Contents of /Users/runner/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}:" \
+          && find /Users/runner/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION} \
+          && cp /Users/runner/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
+          && tar -czvf miniwasm_"${MINIWASM_VERSION}"_Darwin_"${ARCH_NAME}".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"${MINIWASM_VERSION}"_Darwin_"${ARCH_NAME}".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libwasmvm.dylib ./minitiad
+      # - name: Build and Package for Darwin ADM642
+      #   run: |
+      #     cd ../miniwasm \
+      #     && make build \
+      #     && cd ./build \
+      #     && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm* \
+      #     && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
+      #     && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
+      #     && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+      #     && rm -rf ./libwasmvm.dylib ./minitiad   
   
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -61,8 +61,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           go mod tidy
-          go get github.com/CosmWasm/wasmvm@${WASMVM_VERSION}
+          go get github.com/CosmWasm/wasmvm/v2@${WASMVM_VERSION}
           
       - name: Print environment variables
         run: |

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           MINIWASM_NETWORK_NAME="miniwasm-1"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV
-          WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | awk '{print $2}')    
+          WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | awk '{print $2}')    
           echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV        
           echo "GOARCH=arm64" >> $GITHUB_ENV
           echo "GOOS=darwin" >> $GITHUB_ENV

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -53,8 +53,8 @@ jobs:
           && ls ~/go/pkg/mod/github.com/ \
           && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/ \
           && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
-          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
-          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   
   
       - name: Release

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -61,8 +61,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/\CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -44,17 +44,6 @@ jobs:
           echo "VERSION=${VERSION}"
           echo "ARCH_NAME=${ARCH_NAME}"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
-      
-      # - name: Build and Package for Darwin ARM64
-      #   run: |
-      #     cd ../miniwasm \
-      #     && make build \
-      #     && cd ./build \
-      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libmovevm.dylib ./ \
-      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libcompiler.dylib ./ \
-      #     && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
-      #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
-      #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
 
       - name: Build and Package for Darwin ARM64
         run: |
@@ -64,8 +53,8 @@ jobs:
           && ls ~/go/pkg/mod/github.com/ \
           && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/ \
           && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
-          && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
-          && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   
   
       - name: Release

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           go mod tidy
-          go get github.com/initia-labs/movevm@${WASMVM_VERSION}
+          go get github.com/CosmWasm/wasmvm@${WASMVM_VERSION}
           
       - name: Print environment variables
         run: |

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -1,0 +1,63 @@
+
+name: Build Darwin ARM64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+      - name: Set environment variables
+        run: |
+          MINIWASM_NETWORK_NAME="miniwasm-1"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV
+          MOVEVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          echo "MOVEVM_VERSION=${MOVEVM_VERSION}" >> $GITHUB_ENV        
+          echo "GOARCH=arm64" >> $GITHUB_ENV
+          echo "GOOS=darwin" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=aarch64" >> $GITHUB_ENV
+          
+      - name: Ensure dependencies
+        run: |
+          go mod tidy
+          go get github.com/initia-labs/movevm@${MOVEVM_VERSION}
+          
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+          echo "ARCH_NAME=${ARCH_NAME}"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
+      
+      - name: Build and Package for Darwin ARM64
+        run: |
+          cd ../miniwasm \
+          && make build \
+          && cd ./build \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
+          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
+          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+  
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            miniwasm_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           MINIWASM_NETWORK_NAME="miniwasm-1"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV
-          WASMVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | awk '{print $2}')    
           echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV        
           echo "GOARCH=arm64" >> $GITHUB_ENV
           echo "GOOS=darwin" >> $GITHUB_ENV

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -61,7 +61,7 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm* \
           && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -61,8 +61,8 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -20,8 +20,8 @@ jobs:
         run: |
           MINIWASM_NETWORK_NAME="miniwasm-1"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV
-          MOVEVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
-          echo "MOVEVM_VERSION=${MOVEVM_VERSION}" >> $GITHUB_ENV        
+          WASMVM_VERSION=$(go list -m github.com/initia-labs/movevm | awk '{print $2}')    
+          echo "WASMVM_VERSION=${WASMVM_VERSION}" >> $GITHUB_ENV        
           echo "GOARCH=arm64" >> $GITHUB_ENV
           echo "GOOS=darwin" >> $GITHUB_ENV
           if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
@@ -35,7 +35,7 @@ jobs:
       - name: Ensure dependencies
         run: |
           go mod tidy
-          go get github.com/initia-labs/movevm@${MOVEVM_VERSION}
+          go get github.com/initia-labs/movevm@${WASMVM_VERSION}
           
       - name: Print environment variables
         run: |
@@ -45,16 +45,26 @@ jobs:
           echo "ARCH_NAME=${ARCH_NAME}"
           echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
       
-      - name: Build and Package for Darwin ARM64
+      # - name: Build and Package for Darwin ARM64
+      #   run: |
+      #     cd ../miniwasm \
+      #     && make build \
+      #     && cd ./build \
+      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libmovevm.dylib ./ \
+      #     && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${WASMVM_VERSION}/api/libcompiler.dylib ./ \
+      #     && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
+      #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+      #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+
+      - name: Build and Package for Darwin ADM642
         run: |
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libmovevm.dylib ./ \
-          && cp ~/go/pkg/mod/github.com/initia-labs/movevm@${MOVEVM_VERSION}/api/libcompiler.dylib ./ \
-          && tar -czvf miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz minitiad libmovevm.dylib libcompiler.dylib \
-          && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
-          && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
+          && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
+          && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libwasmvm.dylib ./minitiad   
   
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -56,29 +56,16 @@ jobs:
       #     && mv ./miniwasm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
       #     && rm -rf ./libmovevm.dylib ./libcompiler.dylib ./minitiad
 
-      - name: Build and Package for Darwin ADM64
+      - name: Build and Package for Darwin ARM64
         run: |
           cd ../miniwasm \
           && make build \
           && cd ./build \
-          && echo "Contents of /Users/runner/go/pkg/mod/github.com/CosmWasm:" \
-          && ls -l /Users/runner/go/pkg/mod/github.com/CosmWasm \
-          && echo "Contents of /Users/runner/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}:" \
-          && find /Users/runner/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION} \
-          && cp /Users/runner/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
-          && tar -czvf miniwasm_"${MINIWASM_VERSION}"_Darwin_"${ARCH_NAME}".tar.gz ./minitiad libwasmvm.dylib \
-          && mv ./miniwasm_"${MINIWASM_VERSION}"_Darwin_"${ARCH_NAME}".tar.gz $GITHUB_WORKSPACE/ \
-          && rm -rf ./libwasmvm.dylib ./minitiad
-      # - name: Build and Package for Darwin ADM642
-      #   run: |
-      #     cd ../miniwasm \
-      #     && make build \
-      #     && cd ./build \
-      #     && ls ~/go/pkg/mod/github.com/CosmWasm/wasmvm* \
-      #     && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
-      #     && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
-      #     && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
-      #     && rm -rf ./libwasmvm.dylib ./minitiad   
+          && ls ~/go/pkg/mod/github.com/ \
+          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@*/internal/api/libwasmvm.dylib ./ \
+          && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
+          && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./libwasmvm.dylib ./minitiad   
   
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -61,6 +61,7 @@ jobs:
           cd ../miniwasm \
           && make build \
           && cd ./build \
+          && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/ \
           && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@"$WASMVM_VERSION"/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -62,7 +62,8 @@ jobs:
           && make build \
           && cd ./build \
           && ls ~/go/pkg/mod/github.com/ \
-          && cp ~/go/pkg/mod/github.com/CosmWasm/wasmvm/v2@*/internal/api/libwasmvm.dylib ./ \
+          && ls ~/go/pkg/mod/github.com/\!cosm\!wasm/ \
+          && cp ~/go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@${WASMVM_VERSION}/internal/api/libwasmvm.dylib ./ \
           && tar -czvf miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz ./minitiad libwasmvm.dylib \
           && mv ./miniwasm_"$MINIWASM_VERSION"_Darwin_"$ARCH".tar.gz $GITHUB_WORKSPACE/ \
           && rm -rf ./libwasmvm.dylib ./minitiad   

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -1,0 +1,53 @@
+
+name: Build Linux AMD64
+
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+
+      - name: Set environment variables
+        run: |
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+          echo "GOOS=linux" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
+
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+
+      - name: Build for Linux AMD64
+        run: |
+          export GOARCH=${GOARCH}
+          export GOOS=${GOOS}
+          make build-linux-with-shared-library
+          cd ./build
+          mkdir -p miniwasm_${VERSION}
+          mv libmovevm.so miniwasm_${VERSION}/libmovevm.${ARCH_NAME}.so
+          mv libcompiler.so miniwasm_${VERSION}/libcompiler.${ARCH_NAME}.so
+          mv minitiad miniwasm_${VERSION}/
+          tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ./build/miniwasm_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -41,8 +41,7 @@ jobs:
           make build-linux-with-shared-library
           cd ./build
           mkdir -p miniwasm_${VERSION}
-          mv libmovevm.so miniwasm_${VERSION}/libmovevm.${ARCH_NAME}.so
-          mv libcompiler.so miniwasm_${VERSION}/libcompiler.${ARCH_NAME}.so
+          mv libwasmvm.so miniwasm_${VERSION}/libwasmvm.${ARCH_NAME}.so
           mv minitiad miniwasm_${VERSION}/
           tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}
 

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -34,6 +34,10 @@ jobs:
           echo "GOOS=${GOOS}"
           echo "VERSION=${VERSION}"
 
+      - name: Find libwasmvm.so
+        run: |
+          find /go/pkg/mod -name "libwasmvm*.so"
+          
       - name: Build for Linux AMD64
         run: |
           export GOARCH=${GOARCH}

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -34,10 +34,6 @@ jobs:
           echo "GOOS=${GOOS}"
           echo "VERSION=${VERSION}"
 
-      - name: Find libwasmvm.so
-        run: |
-          find /go/pkg/mod -name "libwasmvm*.so"
-          
       - name: Build for Linux AMD64
         run: |
           export GOARCH=${GOARCH}
@@ -45,11 +41,6 @@ jobs:
           make build-linux-with-shared-library
           cd ./build
           mkdir -p miniwasm_${VERSION}
-          echo "Contents of build directory:"
-          ls -al          
-          echo "Contents of /go/pkg/mod/github.com:"
-          ls -al /go/pkg/mod/github.com
-          ls /go/pkg/mod/github.com
           mv libwasmvm.so miniwasm_${VERSION}/libwasmvm.${ARCH_NAME}.so
           mv minitiad miniwasm_${VERSION}/
           tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -41,6 +41,8 @@ jobs:
           make build-linux-with-shared-library
           cd ./build
           mkdir -p miniwasm_${VERSION}
+          ls -al
+          ls /go/pkg/mod/github.com
           mv libwasmvm.so miniwasm_${VERSION}/libwasmvm.${ARCH_NAME}.so
           mv minitiad miniwasm_${VERSION}/
           tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -41,7 +41,10 @@ jobs:
           make build-linux-with-shared-library
           cd ./build
           mkdir -p miniwasm_${VERSION}
-          ls -al
+          echo "Contents of build directory:"
+          ls -al          
+          echo "Contents of /go/pkg/mod/github.com:"
+          ls -al /go/pkg/mod/github.com
           ls /go/pkg/mod/github.com
           mv libwasmvm.so miniwasm_${VERSION}/libwasmvm.${ARCH_NAME}.so
           mv minitiad miniwasm_${VERSION}/

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -37,21 +37,21 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          # BuildKit 활성화 및 새 빌더 생성
+          # Activate BuildKit and create a new builder
           docker buildx create --use --name arm64-builder --platform linux/arm64
           docker buildx inspect --bootstrap
 
-          # ARM64용 이미지 빌드
+          # Building images for ARM64
           docker buildx build --platform linux/arm64 --load --tag minitia/minitiad-shared:arm64 . -f Dockerfile.arm64
 
-          # ARM64 이미지를 사용하여 빌드 결과물 추출
+          # Extract build output using ARM64 images
           mkdir -p ./build
           docker create --name temp minitia/minitiad-shared:arm64
           docker cp temp:/usr/local/bin/minitiad ./build/
           docker cp temp:/lib/libwasmvm.so ./build/
           docker rm temp
 
-          # 결과물 패키징
+          # Packaging of results
           cd ./build
           mkdir -p miniwasm_${VERSION}
           mv minitiad miniwasm_${VERSION}/
@@ -59,12 +59,12 @@ jobs:
           tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}
           mv miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz ../
 
-          # 빌드 결과 확인
+          # Check build results
           cd ..
           ls -l
           file miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz
 
-          # 빌더 제거
+          # remove builder
           docker buildx rm arm64-builder
 
       - name: List files

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,79 @@
+
+name: Build Linux ARM64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set environment variables
+        run: |
+          echo "GOARCH=arm64" >> $GITHUB_ENV
+          echo "GOOS=linux" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=aarch64" >> $GITHUB_ENV
+          
+      - name: Build for ARM64
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          # BuildKit 활성화 및 새 빌더 생성
+          docker buildx create --use --name arm64-builder --platform linux/arm64
+          docker buildx inspect --bootstrap
+
+          # ARM64용 이미지 빌드
+          docker buildx build --platform linux/arm64 --load --tag minitia/minitiad-shared:arm64 . -f Dockerfile.arm64
+
+          # ARM64 이미지를 사용하여 빌드 결과물 추출
+          mkdir -p ./build
+          docker create --name temp minitia/minitiad-shared:arm64
+          docker cp temp:/usr/local/bin/minitiad ./build/
+          docker cp temp:/lib/libmovevm.so ./build/
+          docker cp temp:/lib/libcompiler.so ./build/
+          docker rm temp
+
+          # 결과물 패키징
+          cd ./build
+          mkdir -p miniwasm_${VERSION}
+          mv minitiad miniwasm_${VERSION}/
+          mv libmovevm.so miniwasm_${VERSION}/libmovevm.${ARCH_NAME}.so
+          mv libcompiler.so miniwasm_${VERSION}/libcompiler.${ARCH_NAME}.so
+          tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}
+          mv miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz ../
+
+          # 빌드 결과 확인
+          cd ..
+          ls -l
+          file miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz
+
+          # 빌더 제거
+          docker buildx rm arm64-builder
+
+      - name: List files
+        run: ls -l
+        
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+              ./miniwasm_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -48,16 +48,14 @@ jobs:
           mkdir -p ./build
           docker create --name temp minitia/minitiad-shared:arm64
           docker cp temp:/usr/local/bin/minitiad ./build/
-          docker cp temp:/lib/libmovevm.so ./build/
-          docker cp temp:/lib/libcompiler.so ./build/
+          docker cp temp:/lib/libwasmvm.so ./build/
           docker rm temp
 
           # 결과물 패키징
           cd ./build
           mkdir -p miniwasm_${VERSION}
           mv minitiad miniwasm_${VERSION}/
-          mv libmovevm.so miniwasm_${VERSION}/libmovevm.${ARCH_NAME}.so
-          mv libcompiler.so miniwasm_${VERSION}/libcompiler.${ARCH_NAME}.so
+          mv libwasmvm.so miniwasm_${VERSION}/libwasmvm.${ARCH_NAME}.so
           tar -czvf miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz miniwasm_${VERSION}
           mv miniwasm_${VERSION}_Linux_${ARCH_NAME}.tar.gz ../
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,10 +1,9 @@
-
 FROM arm64v8/golang:1.22-bullseye AS go-builder
 
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
 RUN apt update
 RUN apt install -y curl git build-essential
-# debug: for live editing in the image
+# debug: for live editting in the image
 RUN apt install -y vim
 
 WORKDIR /code
@@ -12,16 +11,17 @@ COPY . /code/
 
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libmovevm.`uname -m`.so /lib/libmovevm.so
-RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libcompiler.`uname -m`.so /lib/libcompiler.so
+RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.`uname -m`.so /lib/libwasmvm.so
 
 FROM arm64v8/ubuntu:20.04
 
 WORKDIR /root
 
 COPY --from=go-builder /code/build/minitiad /usr/local/bin/minitiad
-COPY --from=go-builder /lib/libmovevm.so /lib/libmovevm.so
-COPY --from=go-builder /lib/libcompiler.so /lib/libcompiler.so
+COPY --from=go-builder /lib/libwasmvm.so /lib/libwasmvm.so
+
+# for new-metric setup
+COPY --from=go-builder /code/contrib /root/contrib
 
 # rest server
 EXPOSE 1317

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,35 @@
+
+FROM arm64v8/golang:1.22-bullseye AS go-builder
+
+# Install minimum necessary dependencies, build Cosmos SDK, remove packages
+RUN apt update
+RUN apt install -y curl git build-essential
+# debug: for live editing in the image
+RUN apt install -y vim
+
+WORKDIR /code
+COPY . /code/
+
+RUN LEDGER_ENABLED=false make build
+
+RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libmovevm.`uname -m`.so /lib/libmovevm.so
+RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libcompiler.`uname -m`.so /lib/libcompiler.so
+
+FROM arm64v8/ubuntu:20.04
+
+WORKDIR /root
+
+COPY --from=go-builder /code/build/minitiad /usr/local/bin/minitiad
+COPY --from=go-builder /lib/libmovevm.so /lib/libmovevm.so
+COPY --from=go-builder /lib/libcompiler.so /lib/libcompiler.so
+
+# rest server
+EXPOSE 1317
+# grpc
+EXPOSE 9090
+# tendermint p2p
+EXPOSE 26656
+# tendermint rpc
+EXPOSE 26657
+
+CMD ["/usr/local/bin/minitiad", "version"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,7 +11,7 @@ COPY . /code/
 
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.`uname -m`.so /lib/libwasmvm.so
+RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@v*/internal/api/libwasmvm.`uname -m`.so /lib/libwasmvm.so
 
 FROM arm64v8/ubuntu:20.04
 

--- a/shared.Dockerfile
+++ b/shared.Dockerfile
@@ -11,7 +11,7 @@ COPY . /code/
 
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.`uname -m`.so /lib/libwasmvm.so
+RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm/v2@v*/internal/api/libwasmvm.`uname -m`.so /lib/libwasmvm.so
 
 FROM ubuntu:20.04
 


### PR DESCRIPTION
## Changes

- Add build-and-upload.yml: Main workflow coordinating build processes
    - Set up matrix strategy for multiple platforms (Linux, Darwin)
    - Trigger builds for amd64 and arm64 architectures
- Add build-darwin-amd64.yml and build-darwin-arm64.yml: Darwin-specific build workflows
    - Configure macOS environment and build process
    - Support amd64 and arm64 architectures separately
- Add build-linux-amd64.yml and build-linux-arm64.yml: Linux-specific build workflows
    - Set up Ubuntu environment and build process
    - Include steps for amd64 and arm64 builds separately
- Implement automatic uploads to GitHub Releases for all builds

## Rationale and Improvement

This PR sets up comprehensive CI/CD pipelines for building miniwasm binaries across multiple platforms and architectures, ensuring consistent and automated releases. These workflows significantly improve the developer experience by automating the build and release process, reducing manual errors, and ensuring that binaries are available for all supported platforms and architectures.

## Additional Notes

- This PR improves the overall release process and should make it easier for users to access the latest miniwasm binaries for their specific platform.
- The automated nature of these workflows will help maintain consistency across releases and reduce the workload on maintainers.

## Reviewer Considerations

- Please review the workflow files for any potential security concerns or optimizations.