### PR TITLE
ci: validate format and go-fix in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,6 +62,42 @@ jobs:
         env:
           GIT_DIFF: ${{ env.GIT_DIFF }}
           LINT_DIFF: 1
+  format:
+    runs-on: ubuntu-22.04
+    name: format
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+          check-latest: true
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
+      - name: install format tools
+        if: env.GIT_DIFF
+        run: |
+          go install github.com/client9/misspell/cmd/misspell@v0.3.4
+          go install golang.org/x/tools/cmd/goimports@latest
+        env:
+          GIT_DIFF: ${{ env.GIT_DIFF }}
+      - name: run format
+        if: env.GIT_DIFF
+        run: |
+          make format
+          CHANGES_IN_REPO=$(git status --porcelain)
+          if [[ -n "$CHANGES_IN_REPO" ]]; then
+            echo "Repository is dirty after 'make format'. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+            git status && git --no-pager diff
+            exit 1
+          fi
+        env:
+          GIT_DIFF: ${{ env.GIT_DIFF }}
   # Use --check or --exit-code when available (Go 1.19?)
   # https://github.com/golang/go/issues/27005
   tidy:

--- a/.github/workflows/modernize-go.yml
+++ b/.github/workflows/modernize-go.yml
@@ -1,0 +1,39 @@
+name: Modernize Go
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  modernize-go:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+          check-latest: true
+      - name: Modernize go code
+        run: go fix ./...
+      - uses: peter-evans/create-pull-request@v7.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: modernize go code"
+          title: "chore: modernize go code"
+          branch: "chore/modernize-go"
+          delete-branch: true
+          body: |
+            This PR applies `go fix ./...` using the repository's GitHub Actions toolchain.
+
+            It is generated automatically by `.github/workflows/modernize-go.yml`.

--- a/app/abcipp.go
+++ b/app/abcipp.go
@@ -4,7 +4,6 @@ import (
 	"cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,13 +11,17 @@ import (
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/authz"
+
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+
+	appante "github.com/initia-labs/miniwasm/app/ante"
+
 	opchildante "github.com/initia-labs/OPinit/x/opchild/ante"
 	opchildtypes "github.com/initia-labs/OPinit/x/opchild/types"
 	"github.com/initia-labs/initia/abcipp"
 	initiatx "github.com/initia-labs/initia/tx"
 
-	appante "github.com/initia-labs/miniwasm/app/ante"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
 func (app *MinitiaApp) setupABCIPP(mempoolMaxTxs int, wasmConfig wasmtypes.NodeConfig, txCounterStoreKey *storetypes.KVStoreKey, appOpts servertypes.AppOptions) (

--- a/app/ante/minimal.go
+++ b/app/ante/minimal.go
@@ -3,10 +3,11 @@ package ante
 import (
 	errorsmod "cosmossdk.io/errors"
 
+	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
 
 	opchildante "github.com/initia-labs/OPinit/x/opchild/ante"
 	"github.com/initia-labs/initia/app/ante/sigverify"

--- a/app/getter.go
+++ b/app/getter.go
@@ -15,9 +15,10 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 
 	opchildkeeper "github.com/initia-labs/OPinit/x/opchild/keeper"
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	ibctestingtypes "github.com/initia-labs/initia/x/ibc/testing/types"
 	icaauthkeeper "github.com/initia-labs/initia/x/intertx/keeper"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 )
 
 // GetBaseApp returns the base app for the app.

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	tmos "github.com/cometbft/cometbft/libs/os"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/app/modules.go
+++ b/app/modules.go
@@ -70,10 +70,10 @@ import (
 
 // module account permissions
 var maccPerms = map[string][]string{
-	authtypes.FeeCollectorName:  nil,
-	icatypes.ModuleName:         nil,
-	ibcfeetypes.ModuleName:      nil,
-	ibctransfertypes.ModuleName: {authtypes.Minter, authtypes.Burner},
+	authtypes.FeeCollectorName:   nil,
+	icatypes.ModuleName:          nil,
+	ibcfeetypes.ModuleName:       nil,
+	ibctransfertypes.ModuleName:  {authtypes.Minter, authtypes.Burner},
 	opchildtypes.ModuleName:      {authtypes.Minter, authtypes.Burner},
 	tokenfactorytypes.ModuleName: {authtypes.Minter, authtypes.Burner},
 

--- a/integration-tests/e2e/benchmark/config.go
+++ b/integration-tests/e2e/benchmark/config.go
@@ -18,16 +18,16 @@ const (
 
 // BenchConfig defines the parameters for a benchmark run.
 type BenchConfig struct {
-	MemIAVL        bool          `json:"memiavl"`
-	NodeCount      int           `json:"node_count"`
-	AccountCount   int           `json:"account_count"`
-	TxPerAccount   int           `json:"tx_per_account"`
-	GasLimit       uint64        `json:"gas_limit"`
-	Label          string        `json:"label"`
-	Variant        Variant       `json:"variant"`
-	TimeoutCommit  time.Duration `json:"timeout_commit_ms,omitempty"`
-	ValidatorCount int           `json:"validator_count,omitempty"`
-	MaxBlockGas    int64         `json:"max_block_gas,omitempty"`
+	MemIAVL              bool          `json:"memiavl"`
+	NodeCount            int           `json:"node_count"`
+	AccountCount         int           `json:"account_count"`
+	TxPerAccount         int           `json:"tx_per_account"`
+	GasLimit             uint64        `json:"gas_limit"`
+	Label                string        `json:"label"`
+	Variant              Variant       `json:"variant"`
+	TimeoutCommit        time.Duration `json:"timeout_commit_ms,omitempty"`
+	ValidatorCount       int           `json:"validator_count,omitempty"`
+	MaxBlockGas          int64         `json:"max_block_gas,omitempty"`
 	NoAllowQueued        bool          `json:"no_allow_queued,omitempty"`
 	DrainTimeoutOverride time.Duration `json:"drain_timeout_override,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Add `format` job to the lint workflow: runs `make format` and fails if the repo is dirty
- Add `modernize-go.yml`: weekly scheduled workflow that runs `go fix ./...` and opens a PR automatically
- Apply `make format` and `go fix ./...` locally (mechanical changes only)

## Test plan

- [ ] Lint workflow passes on this PR
- [ ] No behavioral changes in the codebase (format/modernize only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code formatting verification to the CI/CD pipeline.
  * Implemented automated Go code modernization workflow (runs weekly or on-demand).
  * Applied internal code organization improvements for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->